### PR TITLE
Add deep equality test for Map

### DIFF
--- a/src/expect.wren
+++ b/src/expect.wren
@@ -18,6 +18,24 @@ class DeepEqual {
             var d = b[i]
             if (c is List && d is List) {
                 if (!DeepEqual.list(c,d)) return false
+            } else if (c is Map && d is Map) {
+                if (!DeepEqual.map(c,d)) return false
+            } else if (c != d) {
+                return false
+            }
+        }
+        return true
+    }
+    static map(a,b) {
+        if (a.count != b.count) return false
+        for (entry in a) {
+            if (!b.containsKey(entry.key)) return false
+            var c = entry.value
+            var d = b[entry.key]
+            if (c is List && d is List) {
+                if (!DeepEqual.list(c,d)) return false
+            } else if (c is Map && d is Map) {
+                if (!DeepEqual.map(c,d)) return false
             } else if (c != d) {
                 return false
             }
@@ -33,11 +51,7 @@ class Expect {
     static value(v) { Expect.new(v) }
     toBe(v) { toEqual(v) }
     equalMaps_(v) {
-        if (_value.count != v.count) return false
-        for (k in _value.keys) {
-            if (_value[k] != v[k]) return false
-        }
-        return true
+        return DeepEqual.map(_value,v)
     }
     toIncludeSameItemsAs(v) {
         if (_value.count != v.count) return false


### PR DESCRIPTION
Found the need for this while implementing exercism exercise [binary-search-tree](https://github.com/exercism/problem-specifications/blob/a4230684e5d65210863e5d4e5cffa416e77cdce7/exercises/binary-search-tree/canonical-data.json#L53)