### PR TITLE
(enh) Add negated equality methods

### DIFF
--- a/src/expect.wren
+++ b/src/expect.wren
@@ -46,31 +46,32 @@ class Expect {
     toBe(v) { toEqual(v) }
     toNotBe(v) { toNotEqual(v) }
 
-    toEqual(v) { toEqual_(v, true) }
-    toNotEqual(v) { toEqual_(v, false) }
+    toEqual(v) { toEqual_(v, false) }
+    toNotEqual(v) { toEqual_(v, true) }
 
-    toEqual_(v, isPositive) {
-        var not = isPositive ? "" : "not "
-        var method = isPositive ? "toEqual" : "toNotEqual"
+    toEqual_(v, isNegated) {
+        var not = isNegated ? "not " : ""
+        var method = isNegated ? "toNotEqual" : "toEqual"
         if (_value is List && v is List) {
             assert(
-                expr(DeepEqual.isEqual(_value,v), isPositive),
+                expr(DeepEqual.isEqual(_value,v), isNegated),
                 "Expected list %(printValue_(_value)) %(not)to be %(printValue_(v))"
             )
             return
         }
         if (v is Map && _value is Map) {
             assert(
-                expr(DeepEqual.isEqual(_value,v), isPositive),
+                expr(DeepEqual.isEqual(_value,v), isNegated),
                 "Expected %(_value) %(not)to be %(v)"
             )
             return
         }
-        assert(expr(_value == v, isPositive), buildErrorMessage_(v, _value, method))
+        assert(expr(_value == v, isNegated), buildErrorMessage_(v, _value, method))
     }
-    expr(expression, isPositive) {
-        return ( expression &&  isPositive) ||
-               (!expression && !isPositive)
+    expr(expression, isNegated) {
+        // a boolean XOR
+        return ( expression && !isNegated) ||
+               (!expression &&  isNegated)
     }
 
     // Numeric less-than, greater-than tests
@@ -104,7 +105,10 @@ class Expect {
     }
 
     // Error tests
-    abortsWith(err) {
+    #!deprecated
+    abortsWith(err) { toAbortWith(err) }
+
+    toAbortWith(err) {
         var f = Fiber.new { _value.call() }
         var result = f.try()
         assert(result.toString == err, "Expected error '%(err)' but got %(result)")
@@ -115,8 +119,8 @@ class Expect {
 
     // utility methods
     raise(message) { ExpectError.throw(message) }
-    assert(expression, errMsg) {
-        if (!expression) raise(errMsg)
+    assert(expression, errorMessage) {
+        if (!expression) raise(errorMessage)
     }
     printValue_(v) {
         if (v is String) {

--- a/src/expect.wren
+++ b/src/expect.wren
@@ -39,69 +39,101 @@ class DeepEqual {
 
 class Expect {
     construct new(value) { _value = value }
-    raise(message) { ExpectError.throw(message) }
     static that(v) { Expect.new(v) }
     static value(v) { Expect.new(v) }
+
+    // Equality tests
     toBe(v) { toEqual(v) }
-    toIncludeSameItemsAs(v) {
-        if (_value.count != v.count) return false
-        for (item in _value) {
-            if (!v.contains(item)) return false
+    toNotBe(v) { toNotEqual(v) }
+
+    toEqual(v) { toEqual_(v, true) }
+    toNotEqual(v) { toEqual_(v, false) }
+
+    toEqual_(v, isPositive) {
+        var not = isPositive ? "" : "not "
+        var method = isPositive ? "toEqual" : "toNotEqual"
+        if (_value is List && v is List) {
+            assert(
+                expr(DeepEqual.isEqual(_value,v), isPositive),
+                "Expected list %(printValue_(_value)) %(not)to be %(printValue_(v))"
+            )
+            return
         }
-        return true
+        if (v is Map && _value is Map) {
+            assert(
+                expr(DeepEqual.isEqual(_value,v), isPositive),
+                "Expected %(_value) %(not)to be %(v)"
+            )
+            return
+        }
+        assert(expr(_value == v, isPositive), buildErrorMessage_(v, _value, method))
+    }
+    expr(expression, isPositive) {
+        return ( expression &&  isPositive) ||
+               (!expression && !isPositive)
+    }
+
+    // Numeric less-than, greater-than tests
+    toBeGreaterThan(v) {
+        assert(_value > v, "Expected %(_value) to be greater than %(v)")
+    }
+    toBeGreaterThanOrEqual(v) {
+        assert(_value >= v, "Expected %(_value) to be greater than or equal to %(v)")
+    }
+    toBeLessThan(v) {
+        assert(_value < v, "Expected %(_value) to be less than %(v)")
+    }
+    toBeLessThanOrEqual(v) {
+        assert(_value <= v, "Expected %(_value) to be less than or equal to %(v)")
+    }
+
+    // List element tests
+    toIncludeSameItemsAs(v) {
+        assert(_value.count == v.count, "Expected %(_value) to have same count as %(v)")
+        for (item in _value) {
+            assert(v.contains(item), "Expected %(_value) to have same items as %(v) ('%(item)' is missing)")
+        }
+    }
+
+    // Nullity
+    toBeDefined() {
+        assert(_value != null, "Expected %(_value) to be defined (not null)")
+    }
+    toBeNull() {
+        assert(_value == null, "Expected %(_value) to be null")
+    }
+
+    // Error tests
+    abortsWith(err) {
+        var f = Fiber.new { _value.call() }
+        var result = f.try()
+        assert(result.toString == err, "Expected error '%(err)' but got %(result)")
     }
     toNotAbort() {
         // no need to do anything
     }
-    abortsWith(err) {
-        var f = Fiber.new { _value.call() }
-        var result = f.try()
-        if (result!=err) {
-            raise("Expected error '%(err)' but got none")
-        }
+
+    // utility methods
+    raise(message) { ExpectError.throw(message) }
+    assert(expression, errMsg) {
+        if (!expression) raise(errMsg)
     }
-    toBeGreaterThanOrEqual(v) {
-        if (_value >= v) return
-        raise("Expected %(_value) to be greater than or equal to %(v)")
-    }
-    toBeLessThanOrEqual(v) {
-        if (_value <= v) return
-        raise("Expected %(_value) to be less than or equal to %(v)")
-    }
-    printValue(v) {
+    printValue_(v) {
         if (v is String) {
             return "`%(v)`"
         } else if (v is List) {
-            return "[" + v.map {|x| printValue(x) }.join(", ") +  "]"
+            return "[" + v.map {|x| printValue_(x) }.join(", ") +  "]"
         } else {
             return "%(v)"
         }
     }
-    toBeDefined() {
-        if (_value != null) return
-        raise("Expected %(_value) to be defined (not null).")
-    }
-    toEqual(v) {
-        if (_value is List && v is List) {
-            if (!DeepEqual.isEqual(_value,v)) {
-                raise("Expected list %(printValue(_value)) to be %(printValue(v))")
-            }
-            return
-        }
-        if (v is Map && _value is Map) {
-            if (!DeepEqual.isEqual(_value,v)) {
-                raise("Expected %(_value) to be %(v)")
-            }
-            return
-        }
-        if (_value == v) return
-
+    buildErrorMessage_(expected, received, methodName) {
         var fade = "%(Color.BLACK + Color.BOLD)"
-        var err="%(fade)expect(%(Color.RESET + Color.RED)received%(fade)).toEqual(%(Color.RESET + Color.GREEN)expected%(fade)) // deep equality\n\n"
+        var err="%(fade)expect(%(Color.RESET + Color.RED)received%(fade)).%(methodName)(%(Color.RESET + Color.GREEN)expected%(fade)) // deep equality\n\n"
         err = err + "%(Color.WHITE + Color.BOLD)Expected:%(Color.RESET) "
-        err = err + Color.GREEN + printValue(v) + Color.RESET + "\n"
+        err = err + Color.GREEN + printValue_(expected) + Color.RESET + "\n"
         err = err + "%(Color.WHITE + Color.BOLD)Received:%(Color.RESET) "
-        err = err + Color.RED + printValue(_value) + Color.RESET
-        raise("%(err)")
+        err = err + Color.RED + printValue_(received) + Color.RESET
+        return err
     }
 }

--- a/tests/expect.wren
+++ b/tests/expect.wren
@@ -110,6 +110,6 @@ Testie.test("Expect tests") {|do, skip|
 
     Expect.that {
       Expect.that {42}.abortsWith("foo")
-    }.abortsWith("Expected error 'foo' but got 42")
+    }.toAbortWith("Expected error 'foo' but got 42")
   }
 }

--- a/tests/expect.wren
+++ b/tests/expect.wren
@@ -98,4 +98,18 @@ Testie.test("Expect tests") {|do, skip|
       Expect.value(a).toNotEqual(b)
     }.abortsWith(err)
   }
+
+  do.test("exceptions") {
+    Expect.that {
+      Expect.value(1).toNotAbort()
+    }.toNotAbort()
+
+    Expect.that {
+      null.count
+    }.abortsWith("Null does not implement 'count'.")
+
+    Expect.that {
+      Expect.that {42}.abortsWith("foo")
+    }.abortsWith("Expected error 'foo' but got 42")
+  }
 }

--- a/tests/expect.wren
+++ b/tests/expect.wren
@@ -1,0 +1,101 @@
+import "../testie" for Testie
+import "../src/expect" for Expect
+import "../vendor/colors" for Colors as Color
+
+Testie.test("Expect tests") {|do, skip|
+
+  do.test("equality") {
+    Expect.value(1).toBe(1)
+    Expect.value(1).toEqual(1)
+  }
+  do.test("expected equality failures") {
+    var err = Expect.new("").buildErrorMessage_(2, 1, "toEqual")
+    Expect.that {
+      Expect.value(1).toEqual(2)
+    }.abortsWith(err)
+
+    Expect.value(1).toNotBe(2)
+    Expect.value(1).toNotEqual(2)
+  }
+
+  do.test("numeric comparison") {
+    Expect.that(1).toBeGreaterThanOrEqual(1)
+    Expect.that(1).toBeGreaterThanOrEqual(0)
+    Expect.that(1).toBeGreaterThan(0)
+
+    Expect.that {
+      Expect.value(1).toBeGreaterThanOrEqual(2)
+    }.abortsWith("Expected 1 to be greater than or equal to 2")
+    Expect.that {
+      Expect.value(1).toBeGreaterThan(2)
+    }.abortsWith("Expected 1 to be greater than 2")
+
+    Expect.that(1).toBeLessThanOrEqual(1)
+    Expect.that(1).toBeLessThanOrEqual(2)
+    Expect.that(1).toBeLessThan(2)
+
+    Expect.that {
+      Expect.value(1).toBeLessThanOrEqual(0)
+    }.abortsWith("Expected 1 to be less than or equal to 0")
+    Expect.that {
+      Expect.value(1).toBeLessThan(0)
+    }.abortsWith("Expected 1 to be less than 0")
+  }
+
+  do.test("nullity") {
+    Expect.value(1).toBeDefined()
+    Expect.that {
+      Expect.value(null).toBeDefined()
+    }.abortsWith("Expected null to be defined (not null)")
+
+    Expect.value(null).toBeNull()
+    Expect.that {
+      Expect.value("hello").toBeNull()
+    }.abortsWith("Expected hello to be null")
+  }
+
+  do.test("lists") {
+    Expect.value([1,2,3]).toEqual([1,2,3])
+    Expect.value([1,2,3]).toNotEqual([2,3])
+
+    Expect.value([1,2,3]).toIncludeSameItemsAs([3,1,2])
+  }
+
+  do.test("maps") {
+    Expect.value({"A":"B","C":"D"}).toEqual({"C":"D","A":"B"})
+    Expect.value({"A":"B","C":"D"}).toNotEqual({"A":"B","C":"e"})
+  }
+
+  do.test("class that doesn't implement `==`") {
+    class Foo {
+      construct new(v) { _v = v }
+      toString { _v }
+    }
+    var a = Foo.new("hello")
+    Expect.value(a).toEqual(a)  // same object is equal
+
+    var b = Foo.new("hello")
+    Expect.value(a).toNotEqual(b)  // different object isn't equal
+
+    var err = Expect.new("").buildErrorMessage_(a, b, "toEqual")
+    Expect.that {
+      Expect.value(a).toEqual(b)
+    }.abortsWith(err)
+  }
+
+  do.test("class that does implement `==`") {
+    class Bar {
+      construct new(v) { _v = v }
+      toString { _v }
+      ==(other) { _v == other.toString }
+    }
+    var a = Bar.new("world")
+    var b = Bar.new("world")
+    Expect.value(a).toEqual(b)
+
+    var err = Expect.new("").buildErrorMessage_(a, b, "toNotEqual")
+    Expect.that {
+      Expect.value(a).toNotEqual(b)
+    }.abortsWith(err)
+  }
+}


### PR DESCRIPTION
Resolves #2.

* Expect test methods:
    * toBe, toEqual
    * toNotBe, toNotEqual
    * toBeGreaterThan, toBeGreaterThanOrEqual, toBeLessThan, toBeLessThanOrEqual
    * toIncludeSameItemsAs
    * toBeDefined, toBeNull
    * abortsWith, toNotAbort
* adds an `assert(expression, errorMessage)` method