### PR TITLE
(fix) abort Expect tests

### DIFF
--- a/src/expect.wren
+++ b/src/expect.wren
@@ -116,6 +116,10 @@ class Expect {
         if (f.error && f.error is ExpectError) {
             errorMessage = f.error.error
         }
+        if (errorMessage == null) {
+            raise("Expected error '%(expectedMessage)' but no error occurred")
+            return
+        }
         assert(errorMessage == expectedMessage, "Expected error '%(expectedMessage)' but got %(errorMessage)")
     }
     toNotAbort() {

--- a/src/expect.wren
+++ b/src/expect.wren
@@ -110,7 +110,7 @@ class Expect {
 
     toAbortWith(expectedMessage) {
         var f = Fiber.new { _value.call() }
-        var result = f.try()
+        f.try()
         var errorMessage = f.error
         // an ExpectError has the string error in it's `error` accessor
         if (f.error && f.error is ExpectError) {
@@ -124,7 +124,7 @@ class Expect {
     }
     toNotAbort() {
         var f = Fiber.new { _value.call() }
-        var result = f.try()
+        f.try()
         assert(f.error == null, "Expected no error but got: %(f.error)")
     }
 

--- a/src/expect.wren
+++ b/src/expect.wren
@@ -106,15 +106,22 @@ class Expect {
 
     // Error tests
     #!deprecated
-    abortsWith(err) { toAbortWith(err) }
+    abortsWith(errorMessage) { toAbortWith(errorMessage) }
 
-    toAbortWith(err) {
+    toAbortWith(expectedMessage) {
         var f = Fiber.new { _value.call() }
         var result = f.try()
-        assert(result.toString == err, "Expected error '%(err)' but got %(result)")
+        var errorMessage = f.error
+        // an ExpectError has the string error in it's `error` accessor
+        if (f.error && f.error is ExpectError) {
+            errorMessage = f.error.error
+        }
+        assert(errorMessage == expectedMessage, "Expected error '%(expectedMessage)' but got %(result)")
     }
     toNotAbort() {
-        // no need to do anything
+        var f = Fiber.new { _value.call() }
+        var result = f.try()
+        assert(f.error == null, "Expected no error but got: %(f.error)")
     }
 
     // utility methods

--- a/src/expect.wren
+++ b/src/expect.wren
@@ -116,7 +116,7 @@ class Expect {
         if (f.error && f.error is ExpectError) {
             errorMessage = f.error.error
         }
-        assert(errorMessage == expectedMessage, "Expected error '%(expectedMessage)' but got %(result)")
+        assert(errorMessage == expectedMessage, "Expected error '%(expectedMessage)' but got %(errorMessage)")
     }
     toNotAbort() {
         var f = Fiber.new { _value.call() }

--- a/tests/expect.wren
+++ b/tests/expect.wren
@@ -101,8 +101,7 @@ Testie.test("Expect tests") {|do, skip|
 
   do.test("exceptions") {
     Expect.that {
-      var b = 3
-      return b
+      Expect.that { 1 + 2 + 3 }.toNotAbort()
     }.toNotAbort()
 
     Expect.that {
@@ -110,7 +109,7 @@ Testie.test("Expect tests") {|do, skip|
     }.abortsWith("Null does not implement 'count'.")
 
     Expect.that {
-      Expect.that {42}.abortsWith("foo")
-    }.toAbortWith("Expected error 'foo' but got 42")
+      Expect.that { 42 }.abortsWith("foo")
+    }.toAbortWith("Expected error 'foo' but got null")
   }
 }

--- a/tests/expect.wren
+++ b/tests/expect.wren
@@ -104,12 +104,21 @@ Testie.test("Expect tests") {|do, skip|
       Expect.that { 1 + 2 + 3 }.toNotAbort()
     }.toNotAbort()
 
+    // expected abort happens
     Expect.that {
       null.count
     }.abortsWith("Null does not implement 'count'.")
 
+    // expected abort, but no error occurs
     Expect.that {
       Expect.that { 42 }.abortsWith("foo")
-    }.toAbortWith("Expected error 'foo' but got null")
+    }.toAbortWith("Expected error 'foo' but no error occurred")
+
+    // expected booger, but entirely different error occurs
+    Expect.that {
+      Expect.that {
+        null.count
+      }.abortsWith("booger")
+    }.toAbortWith("Expected error 'booger' but got Null does not implement 'count'.")
   }
 }

--- a/tests/expect.wren
+++ b/tests/expect.wren
@@ -101,7 +101,8 @@ Testie.test("Expect tests") {|do, skip|
 
   do.test("exceptions") {
     Expect.that {
-      Expect.value(1).toNotAbort()
+      var b = 3
+      return b
     }.toNotAbort()
 
     Expect.that {


### PR DESCRIPTION
- Fixes `toNotAbort` to actually be functional