### PR TITLE
Adds more granular capability controls

### DIFF
--- a/src/capabilities.wren
+++ b/src/capabilities.wren
@@ -1,9 +1,27 @@
 class Capabilities {
-  static hasMirror {
-    var f = Fiber.new {
-      import "mirror"
+  static tryImport_ (fn) {
+    var f = Fiber.new(fn) 
+    var module = f.try()
+    return f.error ? null : module
+  }
+  static hasMirror { tryImportMirror }
+
+  static tryImportMirror {
+    return tryImport_ {
+      import "mirror" for Mirror
+      return Mirror
     }
-    f.try()
-    return f.error ? false : true
+  }
+  static tryImportFile { 
+    return tryImport_ {
+      import "io" for File
+      return File
+    }
+  }
+  static tryImportRepl {
+    return tryImport_ {
+      import "repl" for Lexer, Token
+      return [Lexer, Token]
+    }
   }
 }

--- a/src/stacktrace_report.wren
+++ b/src/stacktrace_report.wren
@@ -1,16 +1,14 @@
 import "../vendor/colors" for Colors as Color
-import "io" for File
 import "./capabilities" for Capabilities
-var Mirror = null
+var Mirror = Capabilities.tryImportMirror
+var Repl = Capabilities.tryImportRepl
 var Lexer = null
 var Token = null
-if (Capabilities.hasMirror) {
-  import "mirror" for Mirror as M
-  Mirror = M
-  import "repl" for Lexer as L, Token as T
-  Lexer = L
-  Token = T
+if (Repl) {
+  Lexer = Repl[0]
+  Token = Repl[1]
 }
+var File = Capabilities.tryImportFile
 
 class Highlighter {
   construct new(code) {
@@ -49,14 +47,23 @@ class StackTraceReport {
   }
 
   toString {
-    return codeSummary() + "\n" + "\n" + traceSummary()
+    if (File) {
+      return codeSummary() + "\n" + "\n" + traceSummary()
+    } else {
+      return traceSummary()
+    }
   }
+
   print() {
     System.print(this)
   }
 
   highlight(line) {
-    return Highlighter.new(line).toString
+    if (Lexer) {
+      return Highlighter.new(line).toString
+    } else {
+      return line
+    }
   }
 
   codeSummary() {


### PR DESCRIPTION
I love this module, the only problem I've ever had with it is that there is it will fail if any of the non-core builtins aren't included in the runtime you are using. 

Maybe this isn't the best way to do this, but I've modified `stacktrace_report` to have conditional imports for each of the capabilities and hide and show different features accordingly. 

Tests all still run fine with wrenc

# Note
The main `testie` module also uses `"io"` and `"os"` which isn't a huge issue since my runtime also implements them. That being said I don't implement `Process.exit`, but if there is an error it terminates beforehand anyway due to mirror not being implemented either. 